### PR TITLE
Support latest react-native version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.1"
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
Right now the latest version of react-native (v0.56) requires buildTools 26 and this library breaks the build cause it's using v23

![screen shot 2018-07-25 at 5 59 55 pm](https://user-images.githubusercontent.com/1247834/43230012-bd8f4eb0-9034-11e8-8eb7-3adc96bc645a.png)

This PR fixes the issue.